### PR TITLE
Prevent use-after-free during list iteration

### DIFF
--- a/src/http_request.c
+++ b/src/http_request.c
@@ -67,8 +67,8 @@ static http_header_handle_t http_headers_in[] = {
 
 void http_handle_header(http_request_t *r, http_out_t *o)
 {
-    list_head *pos;
-    list_for_each (pos, &(r->list)) {
+    list_head *pos, *n;
+    list_for_each_safe (pos, n, &(r->list)) {
         http_header_t *header = list_entry(pos, http_header_t, list);
         for (http_header_handle_t *header_in = http_headers_in;
              strlen(header_in->name) > 0; header_in++) {

--- a/src/list.h
+++ b/src/list.h
@@ -62,7 +62,8 @@ static inline int list_empty(struct list_head *head)
 
 #define list_entry(ptr, type, member) container_of(ptr, type, member)
 
-#define list_for_each(pos, head) \
-    for (pos = (head)->next; pos != (head); pos = pos->next)
+#define list_for_each_safe(pos, n, head)                   \
+    for (pos = (head)->next, n = pos->next; pos != (head); \
+         pos = n, n = pos->next)
 
 #endif


### PR DESCRIPTION
This commit eliminates heap-use-after-free warning identified by
ThreadSanitizer when calling `list_for_each` along with `list_del`.
`list_del` will leave the pointer invalid, therefore a looping method
that saves the next pointer to a temporary variable is needed.